### PR TITLE
Refactor CLI scaffolding architecture and refresh README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,74 @@
 # create-wp-plugin
-CLI tool to create the basic structure of a WordPress plugin
 
-## Requirements
-- PHP >= 8.3
-- Composer >= 8.5
+CLI en PHP para generar rápidamente la estructura base de un plugin de WordPress.
 
+## ¿Qué genera?
 
-## Global installation
-To install the tool globally, run the following command:
+Al ejecutar el comando se crea una carpeta con:
+
+- Estructura recomendada (`assets`, `inc`, `templates`, `languages`, `src`).
+- Archivos `index.php` con _"Silence is golden."_ para evitar indexado.
+- Archivo principal del plugin (`<slug>.php`) con cabecera de WordPress.
+- `readme.txt` base en formato compatible con WordPress.org.
+
+## Requisitos
+
+- PHP `^8.3`
+- Composer `^2`
+
+## Instalación
+
+### Opción 1: uso local del repositorio
+
 ```bash
-composer global require kpaz-dev/create-wp-plugin
+composer install
+php bin/wp-plugin new mi-plugin
 ```
-Make sure to add `~/.composer/vendor/bin` to your `PATH` environment variable.
 
-## Example Usage
-To create a new WordPress plugin, run the following command:
+### Opción 2: instalación global
+
 ```bash
-create-wp-plugin my-plugin
+composer global require kpaz/create-wp-plugin
+wp-plugin new mi-plugin
 ```
-This will create a new directory named `my-plugin` with the basic structure of a WordPress plugin.
+
+> Si usas instalación global, asegúrate de tener `~/.composer/vendor/bin` (o su equivalente en tu sistema) en el `PATH`.
+
+## Uso
+
+```bash
+wp-plugin new <slug-del-plugin>
+```
+
+Ejemplo:
+
+```bash
+wp-plugin new awesome-seo-tools
+```
+
+Esto generará una carpeta `awesome-seo-tools` lista para empezar a desarrollar.
+
+## Estructura del proyecto (este repositorio)
+
+```text
+bin/
+  wp-plugin                   # Entry point CLI
+src/
+  Application.php             # Factory de la aplicación Symfony Console
+  Command/
+    NewPluginCommand.php      # Comando `new`
+  Service/
+    PluginScaffolder.php      # Lógica de generación de archivos y carpetas
+```
+
+## Desarrollo
+
+Validación rápida:
+
+```bash
+composer run lint
+```
+
+## Licencia
+
+MIT. Revisa el archivo [LICENSE](LICENSE).

--- a/bin/wp-plugin
+++ b/bin/wp-plugin
@@ -1,13 +1,11 @@
 #!/usr/bin/env php
 <?php
 
+declare(strict_types=1);
+
 require __DIR__ . '/../vendor/autoload.php';
 
-use Symfony\Component\Console\Application;
-use Kpaz\CreateWpPlugin\Command\NewPluginCommand;
+use Kpaz\CreateWpPlugin\CliApplicationFactory;
 
-$application = new Application('WP Plugin CLI', '1.0.0');
-
-$application->addCommand(new NewPluginCommand());
-
+$application = CliApplicationFactory::create();
 $application->run();

--- a/composer.json
+++ b/composer.json
@@ -1,21 +1,31 @@
 {
     "name": "kpaz/create-wp-plugin",
     "description": "CLI tool to create the basic structure of a WordPress plugin",
+    "type": "project",
+    "require": {
+        "php": "^8.3",
+        "symfony/console": "^8.0"
+    },
     "autoload": {
         "psr-4": {
             "Kpaz\\CreateWpPlugin\\": "src/"
         }
     },
+    "bin": [
+        "bin/wp-plugin"
+    ],
     "authors": [
         {
             "name": "Kevin Paz",
             "email": "pazortizkevindaniel@gmail.com"
         }
     ],
-    "require": {
-        "symfony/console": "^8.0"
-    },
-    "bin": [
-        "bin/wp-plugin"
-    ]
+    "scripts": {
+        "lint": [
+            "php -l src/Application.php",
+            "php -l src/Command/NewPluginCommand.php",
+            "php -l src/Service/PluginScaffolder.php",
+            "php -l bin/wp-plugin"
+        ]
+    }
 }

--- a/src/Application.php
+++ b/src/Application.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kpaz\CreateWpPlugin;
+
+use Kpaz\CreateWpPlugin\Command\NewPluginCommand;
+use Kpaz\CreateWpPlugin\Service\PluginScaffolder;
+use Symfony\Component\Console\Application;
+
+final class CliApplicationFactory
+{
+    public static function create(): Application
+    {
+        $application = new Application('WP Plugin CLI', '1.0.0');
+        $application->add(new NewPluginCommand(new PluginScaffolder()));
+
+        return $application;
+    }
+}

--- a/src/Command/NewPluginCommand.php
+++ b/src/Command/NewPluginCommand.php
@@ -1,117 +1,44 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Kpaz\CreateWpPlugin\Command;
 
+use Kpaz\CreateWpPlugin\Service\PluginScaffolder;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class NewPluginCommand extends Command
+final class NewPluginCommand extends Command
 {
     protected static $defaultName = 'new';
 
-    public function __construct()
+    public function __construct(private readonly PluginScaffolder $pluginScaffolder)
     {
-        parent::__construct('new');
+        parent::__construct(self::$defaultName);
     }
 
     protected function configure(): void
     {
-        $this->setDescription('Create a new WP plugin')
-        ->addArgument('name', InputArgument::REQUIRED, 'Plugin name');
+        $this
+            ->setDescription('Create a new WordPress plugin scaffold')
+            ->addArgument('name', InputArgument::REQUIRED, 'Plugin slug (directory and main file name)');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $name = $input->getArgument('name');
+        /** @var string $name */
+        $name = (string) $input->getArgument('name');
 
-        if(is_dir($name)) {
-            $output->writeln("<error>Directory already exists</error>");
+        if ($this->pluginScaffolder->directoryExists($name)) {
+            $output->writeln('<error>Directory already exists.</error>');
             return Command::FAILURE;
         }
 
-        mkdir($name);
-
-        $directories = [
-            'assets',
-            'assets/css',
-            'assets/js',
-            'assets/img',
-            'inc',
-            'templates',
-            'languages',
-            'src'
-        ];
-
-        foreach ($directories as $dir) {
-            mkdir($name . '/' . $dir, 0755, true);
-            file_put_contents($name . '/' . $dir . '/index.php', "<?php\n// Silence is golden.\n");
-        }
-
-        file_put_contents($name . '/index.php', "<?php\n// Silence is golden.\n");
-
-        $pluginFile = "$name/$name.php";
-
-        $pluginHeader = <<<PHP
-<?php
-/**
- * Plugin Name:       $name
- * Plugin URI:        https://example.com/
- * Description:       A brief description of the plugin.
- * Version:           1.0.0
- * Requires at least: 5.2
- * Requires PHP:      7.2
- * Author:            Your Name
- * Author URI:        https://example.com/
- * License:           GPL v2 or later
- * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
- * Text Domain:       $name
- * Domain Path:       /languages
- */
-
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
-PHP;
-
-        file_put_contents($pluginFile, $pluginHeader);
-
-        $readmeContent = <<<TXT
-=== $name ===
-Contributors: (this should be a list of wordpress.org usernames)
-Donate link: https://example.com/
-Tags: (one, two)
-Requires at least: 5.2
-Tested up to: 6.0
-Requires PHP: 7.2
-Stable tag: 1.0.0
-License: GPLv2 or later
-License URI: https://www.gnu.org/licenses/gpl-2.0.html
-
-A brief description of the plugin.
-
-== Description ==
-
-A longer description of the plugin.
-
-== Installation ==
-
-1. Upload the plugin folder to the `/wp-content/plugins/` directory.
-2. Activate the plugin through the 'Plugins' menu in WordPress.
-
-== Changelog ==
-
-= 1.0.0 =
-* Initial release.
-TXT;
-
-        file_put_contents("$name/readme.txt", $readmeContent);
-
-        $output->writeln("<info>Plugin created successfully!</info>");
+        $this->pluginScaffolder->create($name);
+        $output->writeln('<info>Plugin created successfully!</info>');
 
         return Command::SUCCESS;
     }
-
 }

--- a/src/Service/PluginScaffolder.php
+++ b/src/Service/PluginScaffolder.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kpaz\CreateWpPlugin\Service;
+
+final class PluginScaffolder
+{
+    /**
+     * @var list<string>
+     */
+    private const DIRECTORIES = [
+        'assets',
+        'assets/css',
+        'assets/js',
+        'assets/img',
+        'inc',
+        'templates',
+        'languages',
+        'src',
+    ];
+
+    public function directoryExists(string $name): bool
+    {
+        return is_dir($name);
+    }
+
+    public function create(string $name): void
+    {
+        mkdir($name);
+
+        foreach (self::DIRECTORIES as $directory) {
+            $path = sprintf('%s/%s', $name, $directory);
+
+            mkdir($path, 0755, true);
+            file_put_contents($path . '/index.php', "<?php\n// Silence is golden.\n");
+        }
+
+        file_put_contents($name . '/index.php', "<?php\n// Silence is golden.\n");
+        file_put_contents($name . '/' . $name . '.php', $this->buildPluginHeader($name));
+        file_put_contents($name . '/readme.txt', $this->buildReadme($name));
+    }
+
+    private function buildPluginHeader(string $name): string
+    {
+        return <<<PHP
+<?php
+/**
+ * Plugin Name:       {$name}
+ * Plugin URI:        https://example.com/
+ * Description:       A brief description of the plugin.
+ * Version:           1.0.0
+ * Requires at least: 5.2
+ * Requires PHP:      7.2
+ * Author:            Your Name
+ * Author URI:        https://example.com/
+ * License:           GPL v2 or later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       {$name}
+ * Domain Path:       /languages
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+PHP;
+    }
+
+    private function buildReadme(string $name): string
+    {
+        return <<<TXT
+=== {$name} ===
+Contributors: (this should be a list of wordpress.org usernames)
+Donate link: https://example.com/
+Tags: (one, two)
+Requires at least: 5.2
+Tested up to: 6.0
+Requires PHP: 7.2
+Stable tag: 1.0.0
+License: GPLv2 or later
+License URI: https://www.gnu.org/licenses/gpl-2.0.html
+
+A brief description of the plugin.
+
+== Description ==
+
+A longer description of the plugin.
+
+== Installation ==
+
+1. Upload the plugin folder to the `/wp-content/plugins/` directory.
+2. Activate the plugin through the 'Plugins' menu in WordPress.
+
+== Changelog ==
+
+= 1.0.0 =
+* Initial release.
+TXT;
+    }
+}


### PR DESCRIPTION
### Motivation

- Mejorar la separación de responsabilidades para que la entrada (`bin`) solo arranque la aplicación y la composición de dependencias esté en una fábrica dedicada. 
- Extraer la lógica de generación de ficheros/carpetas para facilitar pruebas y futuras extensiones del generador de plugins. 
- Proveer documentación más clara en el `README.md` (instalación, uso y estructura del repo). 

### Description

- Añadida la fábrica `CliApplicationFactory` en `src/Application.php` para componer y devolver la instancia de `Symfony\Component\Console\Application`. 
- Creado el servicio `PluginScaffolder` en `src/Service/PluginScaffolder.php` que centraliza la creación de directorios, `index.php`, el archivo principal del plugin y `readme.txt`. 
- Refactorizado `NewPluginCommand` para delegar la creación al `PluginScaffolder` y centrarse en la validación de entrada y mensajes al usuario (`src/Command/NewPluginCommand.php`). 
- Actualizado `bin/wp-plugin` para usar la fábrica, y ajustado `composer.json` (requisito explícito de `php`, tipo `project`, y script `lint`); además se reescribió `README.md` en español con instalación, uso y desarrollo. 
- No se utilizó ninguno de los skills listados en `/opt/codex/skills` porque la tarea fue una refactorización local del repositorio. 

### Testing

- Ejecutado `composer run lint` que ejecuta `php -l` sobre los ficheros principales y pasó sin errores. 
- Intento de `composer install` fallido por restricciones de red al acceder a Packagist (`CONNECT tunnel failed, response 403`). 
- Intento de ejecutar el binario `php bin/wp-plugin new ...` mostró que `vendor/autoload.php` falta, por lo que la ejecución funcional depende de poder instalar dependencias con Composer en el entorno donde se ejecute.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a81c63da788325868468dbd431024e)