### PR TITLE
feat: add --docker option to generate WordPress Docker environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Al ejecutar el comando se crea una carpeta con:
 - Archivos `index.php` con _"Silence is golden."_ para evitar indexado.
 - Archivo principal del plugin (`<slug>.php`) con cabecera de WordPress.
 - `readme.txt` base en formato compatible con WordPress.org.
+- Opcionalmente, entorno Docker con WordPress + MariaDB + WP-CLI (`--docker`).
 
 ## Requisitos
 
@@ -37,7 +38,7 @@ wp-plugin new mi-plugin
 ## Uso
 
 ```bash
-wp-plugin new <slug-del-plugin>
+wp-plugin new <slug-del-plugin> [--docker]
 ```
 
 Ejemplo:
@@ -47,6 +48,28 @@ wp-plugin new awesome-seo-tools
 ```
 
 Esto generará una carpeta `awesome-seo-tools` lista para empezar a desarrollar.
+
+
+### Generar con Docker
+
+Si agregas `--docker`, además de la estructura del plugin se generan:
+
+- `docker-compose.yml` con servicios de `wordpress`, `db` (MariaDB) y `wpcli`.
+- `.env.example` con variables para puertos y credenciales.
+
+Ejemplo:
+
+```bash
+wp-plugin new awesome-seo-tools --docker
+```
+
+Luego puedes iniciar el entorno con:
+
+```bash
+cd awesome-seo-tools
+cp .env.example .env
+docker compose up -d
+```
 
 ## Estructura del proyecto (este repositorio)
 

--- a/src/Command/NewPluginCommand.php
+++ b/src/Command/NewPluginCommand.php
@@ -8,6 +8,7 @@ use Kpaz\CreateWpPlugin\Service\PluginScaffolder;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 final class NewPluginCommand extends Command
@@ -23,21 +24,27 @@ final class NewPluginCommand extends Command
     {
         $this
             ->setDescription('Create a new WordPress plugin scaffold')
-            ->addArgument('name', InputArgument::REQUIRED, 'Plugin slug (directory and main file name)');
+            ->addArgument('name', InputArgument::REQUIRED, 'Plugin slug (directory and main file name)')
+            ->addOption('docker', null, InputOption::VALUE_NONE, 'Generate a local Docker setup with WordPress, DB and WP-CLI');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         /** @var string $name */
         $name = (string) $input->getArgument('name');
+        $withDocker = (bool) $input->getOption('docker');
 
         if ($this->pluginScaffolder->directoryExists($name)) {
             $output->writeln('<error>Directory already exists.</error>');
             return Command::FAILURE;
         }
 
-        $this->pluginScaffolder->create($name);
+        $this->pluginScaffolder->create($name, $withDocker);
         $output->writeln('<info>Plugin created successfully!</info>');
+
+        if ($withDocker) {
+            $output->writeln('<comment>Docker environment generated (docker-compose.yml + .env.example).</comment>');
+        }
 
         return Command::SUCCESS;
     }

--- a/src/Service/PluginScaffolder.php
+++ b/src/Service/PluginScaffolder.php
@@ -25,7 +25,7 @@ final class PluginScaffolder
         return is_dir($name);
     }
 
-    public function create(string $name): void
+    public function create(string $name, bool $withDocker = false): void
     {
         mkdir($name);
 
@@ -39,6 +39,11 @@ final class PluginScaffolder
         file_put_contents($name . '/index.php', "<?php\n// Silence is golden.\n");
         file_put_contents($name . '/' . $name . '.php', $this->buildPluginHeader($name));
         file_put_contents($name . '/readme.txt', $this->buildReadme($name));
+
+        if ($withDocker) {
+            file_put_contents($name . '/docker-compose.yml', $this->buildDockerCompose($name));
+            file_put_contents($name . '/.env.example', $this->buildDockerEnvExample($name));
+        }
     }
 
     private function buildPluginHeader(string $name): string
@@ -97,5 +102,80 @@ A longer description of the plugin.
 = 1.0.0 =
 * Initial release.
 TXT;
+    }
+
+    private function buildDockerCompose(string $name): string
+    {
+        $template = <<<'YAML'
+services:
+  db:
+    image: mariadb:11
+    container_name: %PLUGIN%_db
+    restart: unless-stopped
+    environment:
+      MYSQL_DATABASE: ${WORDPRESS_DB_NAME:-wordpress}
+      MYSQL_USER: ${WORDPRESS_DB_USER:-wordpress}
+      MYSQL_PASSWORD: ${WORDPRESS_DB_PASSWORD:-wordpress}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-root}
+    volumes:
+      - db_data:/var/lib/mysql
+
+  wordpress:
+    image: wordpress:php8.3-apache
+    container_name: %PLUGIN%_wordpress
+    depends_on:
+      - db
+    restart: unless-stopped
+    ports:
+      - "${WORDPRESS_PORT:-8080}:80"
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_NAME: ${WORDPRESS_DB_NAME:-wordpress}
+      WORDPRESS_DB_USER: ${WORDPRESS_DB_USER:-wordpress}
+      WORDPRESS_DB_PASSWORD: ${WORDPRESS_DB_PASSWORD:-wordpress}
+    volumes:
+      - wordpress_data:/var/www/html
+      - ./:/var/www/html/wp-content/plugins/%PLUGIN%
+
+  wpcli:
+    image: wordpress:cli
+    container_name: %PLUGIN%_wpcli
+    depends_on:
+      - wordpress
+    working_dir: /var/www/html
+    entrypoint: ["wp"]
+    command: ["--info"]
+    environment:
+      WORDPRESS_DB_HOST: db:3306
+      WORDPRESS_DB_NAME: ${WORDPRESS_DB_NAME:-wordpress}
+      WORDPRESS_DB_USER: ${WORDPRESS_DB_USER:-wordpress}
+      WORDPRESS_DB_PASSWORD: ${WORDPRESS_DB_PASSWORD:-wordpress}
+    volumes:
+      - wordpress_data:/var/www/html
+      - ./:/var/www/html/wp-content/plugins/%PLUGIN%
+
+volumes:
+  db_data:
+  wordpress_data:
+YAML;
+
+        return str_replace('%PLUGIN%', $name, $template);
+    }
+
+    private function buildDockerEnvExample(string $name): string
+    {
+        $template = <<<'ENV'
+# Copy this file to .env and adjust values if needed
+WORDPRESS_PORT=8080
+WORDPRESS_DB_NAME=wordpress
+WORDPRESS_DB_USER=wordpress
+WORDPRESS_DB_PASSWORD=wordpress
+MYSQL_ROOT_PASSWORD=root
+
+# Optional: container name prefix context
+COMPOSE_PROJECT_NAME=%PLUGIN%
+ENV;
+
+        return str_replace('%PLUGIN%', $name, $template);
     }
 }


### PR DESCRIPTION
### Motivation

- Añadir una opción para que el scaffold del plugin pueda generar un entorno Docker local con WordPress, base de datos y WP-CLI tal como se solicitó.
- Facilitar el desarrollo y pruebas locales montando el plugin en `wp-content/plugins/<slug>` y proveyendo variables vía `.env`.

### Description

- Se agregó la opción `--docker` al comando `new` y se lee con `InputOption` en `src/Command/NewPluginCommand.php`, pasando la bandera al scaffolder y mostrando un mensaje cuando se generan los archivos Docker.
- `PluginScaffolder` (`src/Service/PluginScaffolder.php`) acepta ahora un segundo parámetro `bool $withDocker` y opcionalmente crea `docker-compose.yml` y `.env.example` usando plantillas que incluyen servicios para `wordpress`, `db` (MariaDB) y `wpcli` y montan el plugin en el contenedor.
- Se actualizó el `README.md` para documentar la nueva opción `--docker`, listar los archivos generados y mostrar un ejemplo de uso y cómo levantar el entorno con `docker compose`.

### Testing

- Ejecuté `composer run lint` (que invoca `php -l` sobre `src/*` y `bin/wp-plugin`) y todas las verificaciones de sintaxis regresaron `No syntax errors detected`. ✅
- La verificación de instalación de dependencias `composer install` falló debido a una restricción de red/proxy al acceder a Packagist (`curl error 56 / CONNECT tunnel 403`), por lo que no se pudo instalar `vendor/autoload.php`. ⚠️
- No se añadieron tests unitarios en este cambio; la validación se realizó mediante linter/syntax checks incluidos en `composer run lint`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad8841edf483259e365cff9880b870)